### PR TITLE
Use pkg-config to get proper compilation flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,16 @@
 SRC_FILES=$(wildcard *.cpp)
 OBJ_FILES=$(patsubst %.cpp,%.o, ${SRC_FILES}) 
 HEADER_FILES=$(wildcard *.hpp)
-LIBS=-lcurl -ljsoncpp -lpng -lfreetype -lboost_program_options
+
+LIBPNGFLAGS := $(shell pkg-config --cflags --libs libpng)
+LIBCURLFLAGS := $(shell pkg-config --cflags --libs libcurl)
+JSONCPPFLAGS := $(shell pkg-config --cflags --libs jsoncpp)
+FREETYPEFLAGS := $(shell pkg-config --cflags --libs freetype2)
+
+CFLAGS := $(LIBPNGFLAGS) $(LIBCURLFLAGS) $(JSONCPPFLAGS) $(FREETYPEFLAGS) -lboost_program_options
 
 wanikaniwallpaper: ${OBJ_FILES}
-	g++  ${OBJ_FILES} ${LIBS} -o wanikaniwallpaper
+	g++ $(CFLAGS) ${OBJ_FILES} -o wanikaniwallpaper
 
 %.o: %.cpp ${HEADER_FILES}
-	g++ -I/usr/include/freetype2 -o $@ $< -c
+	g++ $(CFLAGS) -I/usr/include/freetype2 -o $@ $< -c

--- a/api.cpp
+++ b/api.cpp
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <sstream>
 #include <curl/curl.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <utf8.h>
 
 std::stringstream buffer;


### PR DESCRIPTION
Hardcoding the include paths and -l flags is non-portable and
error-prone, so use pkg-config to get them properly.

(Sadly boost doesn't support pkg-config.)