### PR TITLE
Fixed problem with -std compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8)
 
 project(wanikaniwallpaper)
+
+add_compile_options(-std=c++11)
 
 find_package(Freetype REQUIRED)
 find_package(PNG REQUIRED)


### PR DESCRIPTION
Hey,

I tried compiling it on WSL, but it crashed due to default C++ standard used in my compiler - it was older than C++11. Also, CMake 3.0 is not available for WSL, so I changed the number to something lower. It works for me without any warnings.

PS `set(CMAKE_CXX_STANDARD 11)` doesn't work with my CMake (2.8.12.2).
PPS haven't checked if my fix works universally, especially on clang.

mrowqa