### PR TITLE
Add build instructions for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@
 *.lai
 *.la
 *.a
+
+# CMake Generated files
+CMakeFiles
+Makefile
+cmake_install.cmake
+CMakeCache.txt
+
+# Generated Wallpapers
+*.png

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Create a wallpaper based on your WaniKani progress.
 
 ## Usage
 
+**Running requires a TTF font with Kanji available. The default is `ipag.ttf`
+which is available [from this repository][ipag].**
+
 ```
 $ ./wanikaniwallpaper --help
 Command line options:
@@ -30,21 +33,24 @@ Command line options:
   --color-burned arg (=0xFFFFFF)      Color for burned characters
   --color-error arg (=0xFF0000)       Color for error'ed characters
   --help                              Produce this help message
-
-These options can also be saved in a config.ini file in this directory.
 ```
 
+These options can also be saved in a config.ini file in this directory.
+
 ## Building
-
-Building on Debian-based linux systems requires the following packages:
-
+#### Debian-based Linux systems
+The following packages are required for building:
  * `libfreetype6-dev`
  * `libutfcpp-dev`
  * `libcurl3-dev`
  * `libjsoncpp-dev`
  * `libboost-program-options-dev`
 
-Running requires a TTF font with Kanji available. The default is `ipag.ttf`
-which is available [from this repository][ipag].
+#### macOS
+The following required packages can be installed with [Homebrew][brew]:
+```
+brew install boost jsoncpp utfcpp
+```
 
 [ipag]: https://github.com/hyoshiok/ttf-ipafont
+[brew]: https://brew.sh


### PR DESCRIPTION
Could be solving #6.

Building is pretty straightforward. Three dependencies are required though:
- `boost`
- `jsoncpp`
- `utfcpp`

The first two can be installed via macOS's pseudo-default package manager [Homebrew](https://brew.sh). For the latter no formula is available yet, so you'd have to manually add them to your include path.

To spare developers from doing so I created a formula that allows you to just run `brew install boost jsoncpp utfcpp` to install all dependencies and created a pull request for Homebrew (Homebrew/homebrew-core#27076).

This PR shouldn't be merged until the Homebrew pull request has gone through. In case that's rejected, I need to change the Readme again to explain how to manually install `utfcpp`.