### PR TITLE
`utf8cpp` as submodule and build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ CMakeCache.txt
 
 # Generated Wallpapers
 *.png
+bin/wanikaniwallpaper
+src/heisig-data.cpp
+src/order-data.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@
 *.la
 *.a
 
+# other files generated while building
+bin/wanikaniwallpaper
+src/heisig-data.cpp
+src/order-data.cpp
+
 # CMake Generated files
 CMakeFiles
 Makefile
@@ -20,6 +25,3 @@ CMakeCache.txt
 
 # Generated Wallpapers
 *.png
-bin/wanikaniwallpaper
-src/heisig-data.cpp
-src/order-data.cpp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "utfcpp"]
+	path = utfcpp
+	url = https://github.com/nemtrif/utfcpp
+[submodule "lib/utfcpp"]
+	path = lib/utfcpp
+	url = https://github.com/nemtrif/utfcpp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "utfcpp"]
-	path = utfcpp
-	url = https://github.com/nemtrif/utfcpp
 [submodule "lib/utfcpp"]
 	path = lib/utfcpp
 	url = https://github.com/nemtrif/utfcpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ pkg_check_modules(JSONCPP jsoncpp)
 
 include_directories(
   src
+  include
   ${FREETYPE_INCLUDE_DIRS}
   ${PNG_INCLUDE_DIRS}
   ${CURL_INCLUDE_DIRS}
@@ -48,6 +49,8 @@ file(READ ${CMAKE_SOURCE_DIR}/heisig HEISIG)
 configure_file("src/order-data.cpp.in" "src/order-data.cpp")
 configure_file("src/heisig-data.cpp.in" "src/heisig-data.cpp")
 
+set(CMAKE_BINARY_DIR "bin")
+
 add_executable(wanikaniwallpaper ${SRC})
 
 target_link_libraries(wanikaniwallpaper
@@ -55,5 +58,9 @@ target_link_libraries(wanikaniwallpaper
   ${PNG_LIBRARIES}
   ${CURL_LIBRARIES}
   ${Boost_LIBRARIES}
-  ${JSONCPP_LIBRARIES})
+  ${JSONCPP_LIBRARIES}
+  )
+
+set_target_properties(wanikaniwallpaper PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,41 @@ Command line options:
 These options can also be saved in a config.ini file in this directory.
 
 ## Building
+
+You can build and compile the project with `cmake` after installing the
+dependencies:
+
+```bash
+cmake . && cmake --build .
+```
+
 #### Debian-based Linux systems
+
 The following packages are required for building:
+
  * `libfreetype6-dev`
  * `libutfcpp-dev`
  * `libcurl3-dev`
  * `libjsoncpp-dev`
  * `libboost-program-options-dev`
+ * `cmake`
+ * `make`
+
+#### RPM-based Linux systems (fedora)
+
+The following `dnf` packages are required for building:
+ * `boost-devel`
+ * `curlpp-devel`
+ * `freetype-devel`
+ * `jsoncpp-devel`
+ * `cmake`
+ * `make`
+
+##### **`utfcpp`**
+
+`utfcpp` is only packaged for OpenSUSE, for any other distribution, you
+will need to compile `utfcpp` by yourself. You can simply initialise the
+submodule with `git submodule init && git submodule update`.
 
 #### macOS
 The following required packages can be installed with [Homebrew][brew]:

--- a/README.md
+++ b/README.md
@@ -46,12 +46,21 @@ dependencies:
 cmake . && cmake --build .
 ```
 
+### Dependencies
+
+#### **`utfcpp`**
+
+`utfcpp` recommends to be packaged into the user repository and is not packaged
+for all major distributions, you will need to compile `utfcpp` by yourself. You
+can simply add it with
+
+`git submodule init && git submodule update`.
+
 #### Debian-based Linux systems
 
 The following packages are required for building:
 
  * `libfreetype6-dev`
- * `libutfcpp-dev`
  * `libcurl3-dev`
  * `libjsoncpp-dev`
  * `libboost-program-options-dev`
@@ -67,12 +76,6 @@ The following `dnf` packages are required for building:
  * `jsoncpp-devel`
  * `cmake`
  * `make`
-
-##### **`utfcpp`**
-
-`utfcpp` is only packaged for OpenSUSE, for any other distribution, you
-will need to compile `utfcpp` by yourself. You can simply initialise the
-submodule with `git submodule init && git submodule update`.
 
 #### macOS
 The following required packages can be installed with [Homebrew][brew]:

--- a/include
+++ b/include
@@ -1,0 +1,1 @@
+lib/utfcpp/source


### PR DESCRIPTION
**Implemented in this PR**

- `utf8cpp` is included as sub module instead of as system package, so that the project can be build independent from the system. This is also the recommended way of installing `utf8cpp` (see [here](https://github.com/nemtrif/utfcpp#installation)).
- Added more information on how to build the project for those not used to cpp projects.
- The binary will be compiled to a `bin` directory

**This solves the following issues**

- #30